### PR TITLE
Allow SQL files to be environment specific

### DIFF
--- a/migration/migration_sql.go
+++ b/migration/migration_sql.go
@@ -118,6 +118,7 @@ func splitSQLStatements(r io.Reader, direction bool) (stmts []string) {
 
 				if !found {
 					buf.Reset()
+					stmts = []string{}
 					return
 				}
 			}

--- a/migration/migration_sql_test.go
+++ b/migration/migration_sql_test.go
@@ -99,6 +99,20 @@ func TestSplitStatements(t *testing.T) {
 			setup:     func() { _ = os.Setenv("GOLANG_ENV", "production") },
 			teardown:  func() { _ = os.Unsetenv("GOLANG_ENV") },
 		},
+		{
+			sql:       envartxt,
+			direction: true,
+			count:     0,
+			setup:     func() { _ = os.Setenv("GOLANG_ENV", "development") },
+			teardown:  func() { _ = os.Unsetenv("GOLANG_ENV") },
+		},
+		{
+			sql:       envartxt,
+			direction: false,
+			count:     0,
+			setup:     func() { _ = os.Setenv("GOLANG_ENV", "development") },
+			teardown:  func() { _ = os.Unsetenv("GOLANG_ENV") },
+		},
 	}
 
 	for _, test := range tests {

--- a/migration/migration_sql_test.go
+++ b/migration/migration_sql_test.go
@@ -1,6 +1,7 @@
 package migration
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,8 @@ func TestSplitStatements(t *testing.T) {
 		sql       string
 		direction bool
 		count     int
+		setup     func()
+		teardown  func()
 	}
 
 	tests := []testData{
@@ -58,26 +61,50 @@ func TestSplitStatements(t *testing.T) {
 			sql:       functxt,
 			direction: true,
 			count:     2,
+			setup:     func() {},
+			teardown:  func() {},
 		},
 		{
 			sql:       functxt,
 			direction: false,
 			count:     2,
+			setup:     func() {},
+			teardown:  func() {},
 		},
 		{
 			sql:       multitxt,
 			direction: true,
 			count:     2,
+			setup:     func() {},
+			teardown:  func() {},
 		},
 		{
 			sql:       multitxt,
 			direction: false,
 			count:     2,
+			setup:     func() {},
+			teardown:  func() {},
+		},
+		{
+			sql:       envartxt,
+			direction: true,
+			count:     2,
+			setup:     func() { _ = os.Setenv("GOLANG_ENV", "production") },
+			teardown:  func() { _ = os.Unsetenv("GOLANG_ENV") },
+		},
+		{
+			sql:       envartxt,
+			direction: false,
+			count:     2,
+			setup:     func() { _ = os.Setenv("GOLANG_ENV", "production") },
+			teardown:  func() { _ = os.Unsetenv("GOLANG_ENV") },
 		},
 	}
 
 	for _, test := range tests {
+		test.setup()
 		stmts := splitSQLStatements(strings.NewReader(test.sql), test.direction)
+		test.teardown()
 		if len(stmts) != test.count {
 			t.Errorf("incorrect number of stmts. got %v, want %v", len(stmts), test.count)
 		}
@@ -121,6 +148,32 @@ drop TABLE histories;
 
 // test multiple up/down transitions in a single script
 var multitxt = `-- +goose Up
+CREATE TABLE post (
+    id int NOT NULL,
+    title text,
+    body text,
+    PRIMARY KEY(id)
+);
+
+-- +goose Down
+DROP TABLE post;
+
+-- +goose Up
+CREATE TABLE fancier_post (
+    id int NOT NULL,
+    title text,
+    body text,
+    created_on timestamp without time zone,
+    PRIMARY KEY(id)
+);
+
+-- +goose Down
+DROP TABLE fancier_post;
+`
+
+// test environment specific scripts
+var envartxt = `-- +goose Env BSD:HUGS GOLANG_ENV:production
+-- +goose Up
 CREATE TABLE post (
     id int NOT NULL,
     title text,


### PR DESCRIPTION
Include within the SQL migration script something along the lines of
the following:

```sql
// -- +goose Env VAR1:production VAR2:1
```

Replace the `VAR1` and `VAR2` with the environment variable names and
adjust the desired values. If the `Env` command is present and no
key/value pairings are **true** then the file will not be executed.